### PR TITLE
Fix many bugs

### DIFF
--- a/hall-of-fame/pull-requests/fix-many-bugs.md
+++ b/hall-of-fame/pull-requests/fix-many-bugs.md
@@ -1,0 +1,1 @@
+[Fix many bugs](https://github.com/textmate/textmate/pull/37)


### PR DESCRIPTION
When textmate was first open sourced, there's a pull request removed all its code and replaced with emacs's.
