### PR TITLE
Add Node's "Use CoffeeScript" PR

### DIFF
--- a/_data/entries.yml
+++ b/_data/entries.yml
@@ -73,3 +73,7 @@
 - title: "It could have been a flame war"
   link: "https://github.com/bmuller/gender_detector/pull/14"
   type: "pull request"
+
+- title: "Use CoffeeScript"
+  link: "https://github.com/joyent/node/pull/2472"
+  type: "pull request"


### PR DESCRIPTION
Added what I believe is a [classic PR](https://github.com/joyent/node/pull/2472) in GitHub history. 

A bold contributor decides to convert the entire Node.js source from JavaScript to CoffeeScript in one commit. The total line count was reduced from 15,896 to 6,501, sparking some interesting and serious (and many not-so-serious) discussions between the Node and JavaScript communities. 

Also, I'm open to a more creative title.
