### PR TITLE
Retards

### DIFF
--- a/_data/entries.yml
+++ b/_data/entries.yml
@@ -89,3 +89,7 @@
 - title: "Paul Irish perf audits reddit mobile"
   link: "https://github.com/reddit/reddit-mobile/issues/247"
   type: "issue"
+
+- title: "Retards"
+  link: https://github.com/nixxquality/WebMConverter/commit/c1ac0baac06fa7175677a4a1bf65860a84708d67
+  type: "commit"


### PR DESCRIPTION
GitHub threatened to take down this repo for using the words `retard` and `retarded`:

![email](https://i.imgur.com/QC51FZz.png)

He responded by changing `retard` to `git` (which really is a nice "hack", btw)
It has sparked a huge debate about censorship and what not in the comments and [on HN](https://news.ycombinator.com/item?id=9966118).
