### PR TITLE
HTTP/2 Spec

### DIFF
--- a/_data/entries.yml
+++ b/_data/entries.yml
@@ -93,3 +93,7 @@
 - title: "Deleted, because of police"
   link: "https://archive.is/r8k7X#30.1%"
   type: "issue"
+
+- title: "HTTP/2 Spec"
+  link: "https://github.com/http2/http2-spec/commit/ac468f3fab9f7092a430eedfd69ee1fb2e23c944"
+  type: "commit"


### PR DESCRIPTION
Every HTTP/2 communication starts with `PRISM`. This actually made it into [RFC 7540, Section 3.5](https://tools.ietf.org/html/rfc7540#section-3.5).
That commit was made in June 2013 after the revelation of the PRISM surveillance program in Snowden's documents.

Read @jgrahamc's [blog post](http://blog.jgc.org/2015/11/the-secret-message-hidden-in-every.html) for more info.
